### PR TITLE
Cr131 add airac reference & CR140 Limit Times to Whole Seconds	

### DIFF
--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -9,21 +9,25 @@ Sub-second precision is considered unneeded for most aviation data, but other fi
 ---
 
 `FIXM Core 4.3.0` defines two types for representing date/time values
-- `DateTimeUtc`, that restricts the standard XML dateTime, is constrained to only allow whole second precision. `DateTimeUtc` is used for typing all aviation-related times, such as the EOBT.
+- `DateTimeUtc`, that restricts the standard XML dateTime, is constrained to only allow whole second precision. `DateTimeUtc` is used for typing all aviation-related times, such as the actual time of arrival.
 - `DateTimeUtcHighPrecision`, that restricts the standard XML dateTime, employs unrestricted sub-second precision. `DateTimeUtcHighPrecision` is used for typing the message timestamps in the FIXM Applications.
 
 Examples: 
 - for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00Z`
+
+```xml
+<actualTimeOfArrival>
+  <time>1969-07-20T20:18:00Z</time>
+```
+
 - for message timestamps, higher precision can be provided: `1969-07-20T20:18:00.458Z`
+```xml
+<timestamp>1969-07-20T20:18:00.458Z</timestamp>
+```
 
 ---
 
-`FIXM Core 4.2.0` defines only one type for representing date/time values, named `Time`, which employs unrestricted sub-second precision and is used for typing aviation-related times and message timestamps. For aviation-related times, it is recommended to encode times with trailing characters `.000Z`. Message timestamps can use higher precision, as needed.
-
-
-Examples: 
-- for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00.000Z`
-- for message timestamps, higher precision can be provided: `1969-07-20T20:18:00.458Z`
+`FIXM Core 4.2.0` defines only one type for representing date/time values, named `Time`, which employs unrestricted sub-second precision and is used for typing aviation-related times and message timestamps. For aviation-related times, it is recommended to encode times  with whole second precision only, or with trailing characters `.000Z`. Message timestamps can use higher precision, as needed.
 
 ---
 
@@ -32,7 +36,7 @@ Examples:
 
 ## AIRAC Effective Date
 
-`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on ICAO published schedule (https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
+`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on [ICAO published schedule](https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
 
 !> **Note to implementers:** When used as the AIRAC reference in the FF-ICE Flight Plan, the AIRAC Effective Date shall be solely interpreted as an indication of the aeronautical data set that has been used by the operator for the computation of the flight plan, and not as the actual date at which that data set will effectively become applicable. Indeed, the date at which a new AIRAC cycle effectively becomes applicable may be subject to regional or domestic procedures and may therefore differ from the ICAO published schedule. For instance, in some Asians countries, a new AIRAC cycle would become effective on 00LCL, which is the day before AIRAC day in UTC as published by ICAO.
 
@@ -40,8 +44,8 @@ Examples:
 
 |Cycle|Ident|**AIRAC Effective Date**|
 |:-|:-|:-|
-|1|2201|**27 JAN 22**|
-|2|2202|**24 FEB 22**|
+|1|2201|27 JAN 22|
+|**2**|**2202**|**`24 FEB 22`**|
 
 The indication that the dataset AIRAC 2202 has been used for the computation of the route/trajectory will be expressed as
 

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -8,9 +8,9 @@ Sub-second precision is considered unneeded for most aviation data, but other fi
 
 ---
 
-`FIXM Core 4.3.0` defines two types for representing date/time values
-- `DateTimeUtc`, that restricts the standard XML dateTime, is constrained to only allow whole second precision. DateTimeUtc is used for typing all aviation-related times, such as the actual time of arrival.
-- `DateTimeUtcHighPrecision`, that restricts the standard XML dateTime, employs unrestricted sub-second precision. DateTimeUtcHighPrecision is used for typing the message timestamps in the FIXM Applications.
+`FIXM Core 4.3.0` defines two types for representing date/time values, both restricting the standard XML dateTime:
+- `DateTimeUtc` is constrained to only allow whole second precision. It is used for typing all aviation-related times, such as the actual time of arrival.
+- `DateTimeUtcHighPrecision` employs unrestricted sub-second precision. It is used for typing the message timestamps in the FIXM Applications.
 
 Examples: 
 - for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00Z`
@@ -25,16 +25,18 @@ Examples:
 
 ---
 
-`FIXM Core 4.2.0` defines only one type for representing date/time values, named `Time`, which employs unrestricted sub-second precision and is used for typing aviation-related times and message timestamps. For aviation-related times, it is recommended to encode times  with whole second precision only, or with trailing characters `.000Z`. Message timestamps can use higher precision, as needed.
+`FIXM Core 4.2.0` defines only one type for representing date/time values, named `Time`, which employs unrestricted sub-second precision and is used for typing indifferently aviation-related times and message timestamps. It is recommended to encode aviation-related times with whole second precision only, or with trailing characters `.000Z`. Message timestamps can use higher precision, as needed.
 
 ```xml
 <!--xmlns:fx="http://www.fixm.aero/flight/4.2"-->	
+<!-- whole second precision only -->
 <fx:actualTimeOfArrival>1969-07-20T20:18:00Z</fx:actualTimeOfArrival>
 ```
 OR 
 
 ```xml
 <!--xmlns:fx="http://www.fixm.aero/flight/4.2"-->	
+<!-- with trailing characters .000Z -->
 <fx:actualTimeOfArrival>1969-07-20T20:18:00.000Z</fx:actualTimeOfArrival>
 ```
 ---
@@ -44,11 +46,9 @@ OR
 
 ## AIRAC Effective Date
 
-`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on [ICAO published schedule](https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
+`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on the [ICAO published schedule](https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
 
-!> **Note to implementers:** When used as the AIRAC reference in the FF-ICE Flight Plan, the AIRAC Effective Date shall be solely interpreted as an indication of the aeronautical data set that has been used by the operator for the computation of the flight plan, and not as the actual date at which that data set will effectively become applicable. Indeed, the date at which a new AIRAC cycle effectively becomes applicable may be subject to regional or domestic procedures and may therefore differ from the ICAO published schedule. For instance, in some Asians countries, a new AIRAC cycle would become effective on 00LCL, which is the day before AIRAC day in UTC as published by ICAO.
-
-Examples:
+Example:
 
 |Cycle|Ident|**AIRAC Effective Date**|
 |:-|:-|:-|
@@ -63,4 +63,5 @@ The indication that the dataset `AIRAC 2202` has been used for the computation o
   <fx:airacReference>2022-02-24Z</fx:airacReference>
 ```
 
+!> **Note to implementers:** When used as the AIRAC reference in the FF-ICE Flight Plan, the AIRAC Effective Date shall be solely interpreted as an indication of the aeronautical data set that has been used by the operator for the computation of the flight plan, and not as the actual date at which that data set will effectively become applicable. Indeed, the date at which a new AIRAC cycle effectively becomes applicable may be subject to regional or domestic procedures and may therefore differ from the ICAO published schedule. For instance, in some Asians countries, a new AIRAC cycle would become effective on 00LCL, which is the day before AIRAC day in UTC as published by ICAO.
 

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -1,6 +1,7 @@
-# Date/Time Specification & AIRAC
+# Date/Time Specification & AIRAC Effective Date
 
-## Date/Time
+## Date/Time Specification
+
 FIXM requires times to be expressed in UTC. A constraint is therefore placed on the FIXM classes used to represent date/time values that imposes the use of the trailing character `Z` to indicate UTC, in line with the W3C XSD specification.
 
 Sub-second precision is considered unneeded for most aviation data, but other fields such as message timestamps can still benefit from higher precision date/times.
@@ -29,5 +30,24 @@ Examples:
 !> **Note to implementers:** The mapping of the XSD type `dateTime` to native structures in various development contexts is not always 1-1 and may exhibit a wide variety of difficulties depending on the tooling and runtime context. In particular, the trailing character `Z` indicating UTC may actually be stripped/omitted, leading to FIXM times being interpreted as local times instead of UTC times by some applications. FIXM implementers are therefore invited to crosscheck that their systems correctly interpret FIXM times as UTC time.
 
 
-## AIRAC references
+## AIRAC Effective Date
+
+`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on ICAO published schedule (https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
+
+!> **Note to implementers:** When used as the AIRAC reference in the FF-ICE Flight Plan, the AIRAC Effective Date shall be solely interpreted as an indication of the aeronautical data set that has been used by the operator for the computation of the flight plan, and not as the actual date at which that data set will effectively become applicable. Indeed, the date at which a new AIRAC cycle effectively becomes applicable may be subject to regional or domestic procedures and may therefore differ from the ICAO published schedule. For instance, in some Asians countries, a new AIRAC cycle would become effective on 00LCL, which is the day before AIRAC day in UTC as published by ICAO.
+
+Examples:
+
+|Cycle|Ident|**AIRAC Effective Date**|
+|:-|:-|:-|
+|1|2201|**27 JAN 22**|
+|2|2202|**24 FEB 22**|
+
+The indication that the dataset AIRAC 2202 has been used for the computation of the route/trajectory will be expressed as
+
+```xml
+<fx:routeInformation>
+  <fx:airacReference>2022-02-24Z</fx:airacReference>
+```
+
 

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -9,8 +9,8 @@ Sub-second precision is considered unneeded for most aviation data, but other fi
 ---
 
 `FIXM Core 4.3.0` defines two types for representing date/time values
-- `DateTimeUtc`, that restricts the standard XML dateTime, is constrained to only allow whole second precision. `DateTimeUtc` is used for typing all aviation-related times, such as the actual time of arrival.
-- `DateTimeUtcHighPrecision`, that restricts the standard XML dateTime, employs unrestricted sub-second precision. `DateTimeUtcHighPrecision` is used for typing the message timestamps in the FIXM Applications.
+- `DateTimeUtc`, that restricts the standard XML dateTime, is constrained to only allow whole second precision. DateTimeUtc is used for typing all aviation-related times, such as the actual time of arrival.
+- `DateTimeUtcHighPrecision`, that restricts the standard XML dateTime, employs unrestricted sub-second precision. DateTimeUtcHighPrecision is used for typing the message timestamps in the FIXM Applications.
 
 Examples: 
 - for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00Z`

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -45,9 +45,10 @@ Examples:
 |Cycle|Ident|**AIRAC Effective Date**|
 |:-|:-|:-|
 |1|2201|27 JAN 22|
-|**2**|**2202**|**`24 FEB 22`**|
+|**2**|**`2202`**|**`24 FEB 22`**|
+|...|...|...|
 
-The indication that the dataset AIRAC 2202 has been used for the computation of the route/trajectory will be expressed as
+The indication that the dataset `AIRAC 2202` has been used for the computation of the route/trajectory will be expressed as:
 
 ```xml
 <fx:routeInformation>

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -1,11 +1,33 @@
-# Date/Time Specification
+# Date/Time Specification & AIRAC
 
-FIXM requires times to be expressed in UTC.
+## Date/Time
+FIXM requires times to be expressed in UTC. A constraint is therefore placed on the FIXM classes used to represent date/time values that imposes the use of the trailing character `Z` to indicate UTC, in line with the W3C XSD specification.
 
-A constraint is placed on class *Base.Types.Time*, the class used to
-represent all date/time values in FIXM, imposes the use of the trailing
-character `Z` to indicate UTC, in line with the W3C XSD specification.
+Sub-second precision is considered unneeded for most aviation data, but other fields such as message timestamps can still benefit from higher precision date/times.
 
-Example: 20th July 1969 at 20:18 UTC is expressed as `1969-07-20T20:18:00.000Z`
+---
+
+`FIXM Core 4.3.0` defines two types for representing date/time values
+- `DateTimeUtc`, that restricts the standard XML dateTime, is constrained to only allow whole second precision. `DateTimeUtc` is used for typing all aviation-related times, such as the EOBT.
+- `DateTimeUtcHighPrecision`, that restricts the standard XML dateTime, employs unrestricted sub-second precision. `DateTimeUtcHighPrecision` is used for typing the message timestamps in the FIXM Applications.
+
+Examples: 
+- for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00Z`
+- for message timestamps, higher precision can be provided: `1969-07-20T20:18:00.458Z`
+
+---
+
+`FIXM Core 4.2.0` defines only one type for representing date/time values, named `Time`, which employs unrestricted sub-second precision and is used for typing aviation-related times and message timestamps. For aviation-related times, it is recommended to encode times with trailing characters `.000Z`. Message timestamps can use higher precision, as needed.
+
+
+Examples: 
+- for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00.000Z`
+- for message timestamps, higher precision can be provided: `1969-07-20T20:18:00.458Z`
+
+---
 
 !> **Note to implementers:** The mapping of the XSD type `dateTime` to native structures in various development contexts is not always 1-1 and may exhibit a wide variety of difficulties depending on the tooling and runtime context. In particular, the trailing character `Z` indicating UTC may actually be stripped/omitted, leading to FIXM times being interpreted as local times instead of UTC times by some applications. FIXM implementers are therefore invited to crosscheck that their systems correctly interpret FIXM times as UTC time.
+
+
+## AIRAC references
+

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -16,19 +16,27 @@ Examples:
 - for aviation-related times, *20th July 1969 at 20:18 UTC* is expressed as `1969-07-20T20:18:00Z`
 
 ```xml
-<actualTimeOfArrival>
-  <time>1969-07-20T20:18:00Z</time>
+<!--xmlns:fx="http://www.fixm.aero/flight/4.3"-->	
+<fx:actualTimeOfArrival>
+  <fx:time>1969-07-20T20:18:00Z</time>
 ```
 
-- for message timestamps, higher precision can be provided: `1969-07-20T20:18:00.458Z`
-```xml
-<timestamp>1969-07-20T20:18:00.458Z</timestamp>
-```
+- for message timestamps, higher precision can be provided, as needed: `1969-07-20T20:18:00.458Z`
 
 ---
 
 `FIXM Core 4.2.0` defines only one type for representing date/time values, named `Time`, which employs unrestricted sub-second precision and is used for typing aviation-related times and message timestamps. For aviation-related times, it is recommended to encode times  with whole second precision only, or with trailing characters `.000Z`. Message timestamps can use higher precision, as needed.
 
+```xml
+<!--xmlns:fx="http://www.fixm.aero/flight/4.2"-->	
+<fx:actualTimeOfArrival>1969-07-20T20:18:00Z</fx:actualTimeOfArrival>
+```
+OR 
+
+```xml
+<!--xmlns:fx="http://www.fixm.aero/flight/4.2"-->	
+<fx:actualTimeOfArrival>1969-07-20T20:18:00.000Z</fx:actualTimeOfArrival>
+```
 ---
 
 !> **Note to implementers:** The mapping of the XSD type `dateTime` to native structures in various development contexts is not always 1-1 and may exhibit a wide variety of difficulties depending on the tooling and runtime context. In particular, the trailing character `Z` indicating UTC may actually be stripped/omitted, leading to FIXM times being interpreted as local times instead of UTC times by some applications. FIXM implementers are therefore invited to crosscheck that their systems correctly interpret FIXM times as UTC time.

--- a/docs/general-guidance/date-time-specification.md
+++ b/docs/general-guidance/date-time-specification.md
@@ -46,7 +46,7 @@ OR
 
 ## AIRAC Effective Date
 
-`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on the [ICAO published schedule](https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
+`FIXM Core 4.3.0` enables implementers, and in particular operators, to indicate, by reference to the AIRAC Effective date, the aeronautical dataset used in the creation of the flight plan and calculation of the route/trajectory. The AIRAC Effective Date is based on the [ICAO published schedule](https://www.icao.int/airnavigation/information-management/Pages/AIRAC.aspx).
 
 Example:
 
@@ -56,7 +56,7 @@ Example:
 |**2**|**`2202`**|**`24 FEB 22`**|
 |...|...|...|
 
-The indication that the dataset `AIRAC 2202` has been used for the computation of the route/trajectory will be expressed as:
+The indication that the aeronautical dataset for cycle `2202` has been used for the computation of the route/trajectory will be expressed as:
 
 ```xml
 <fx:routeInformation>


### PR DESCRIPTION
The proposed updates to the FIXM user manual cover:
- guidance about the encoding of the AIRAC reference, derived from CR131 content and associated discussion forum;
- revised explanations and examples of date time encodings, to reflect the the introduction of the DateTimeUTC/DateTimeUTCHighPrecision (CR140).
The revised page contains examples for both FIXM 4.3.0 and FIXM 4.2.0.